### PR TITLE
fixing notify observers for resources with subpath

### DIFF
--- a/coapthon2/layer/observe.py
+++ b/coapthon2/layer/observe.py
@@ -6,6 +6,7 @@ from coapthon2.messages.request import Request
 from coapthon2.messages.response import Response
 from coapthon2.serializer import Serializer
 from coapthon2.utils import Tree
+from coapthon2.resources.resource import Resource
 
 __author__ = 'Giacomo Tanganelli'
 __version__ = "2.0"
@@ -49,16 +50,15 @@ class ObserveLayer(object):
         self._parent.relation[resource] = observers
         return commands
 
-    def notify(self, node):
+    def notify_by_resource(self, resource):
         """
         Finds the observers that must be notified about the update of the observed resource.
 
-        :type node: coapthon2.utils.Tree
-        :param node: the node which has the deleted resource
+        :type resource: coapthon2.resources.resource.Resource
+        :param resource: the resource which should be updated
         :return: the list of commands that must be executed to notify clients
         """
-        assert isinstance(node, Tree)
-        resource = node.value
+        assert isinstance(resource, Resource)
         observers = self._parent.relation.get(resource)
         if observers is None:
             resource.observe_count += 1
@@ -73,6 +73,18 @@ class ObserveLayer(object):
         resource.observe_count += 1
         self._parent.relation[resource] = observers
         return commands
+
+    def notify(self, node):
+        """
+        Finds the observers that must be notified about the update of the observed resource.
+
+        :type node: coapthon2.utils.Tree
+        :param node: the node which has the resource to update
+        :return: the list of commands that must be executed to notify clients
+        """
+        assert isinstance(node, Tree)
+        resource = node.value
+        return self.notify_by_resource(resource)
 
     def prepare_notification(self, t):
         """

--- a/coapthon2/resources/resource.py
+++ b/coapthon2/resources/resource.py
@@ -401,6 +401,5 @@ class Resource(object):
         return -1
 
     def notify_clients(self):
-        node = self._coap_server.root.find_complete(self.path)
-        if node is not None:
-            self._coap_server.notify(node)
+        self._coap_server.notify(self)
+

--- a/coapthon2/server/coap_protocol.py
+++ b/coapthon2/server/coap_protocol.py
@@ -317,7 +317,7 @@ class CoAP(DatagramProtocol):
         :type node: coapthon2.utils.Tree
         :param node: the node which has the deleted resource
         """
-        commands = self._observe_layer.notify(node)
+        commands = self._observe_layer.notify_by_resource(node)
         if commands is not None:
             threads.callMultipleInThread(commands)
 


### PR DESCRIPTION
the tree.find_complete(self.path) in resource.notify_clients() doesn't work for resources with subpaths (/foo/bar), only for a depth of one of the path (like /foo). But it's not even necessary, as the ObserveLayer just extracts the resource from the tree object.

This patch removes this step and directly delivers the resource object.