### PR TITLE
resource parameters (rt, sz, ct) are only set to default when unset

### DIFF
--- a/coapthon2/server/coap_protocol.py
+++ b/coapthon2/server/coap_protocol.py
@@ -186,9 +186,12 @@ class CoAP(DatagramProtocol):
                 if len(paths) != i:
                     return False
                 resource.path = p
-                resource.content_type = "text/plain"
-                resource.resource_type = "prova"
-                resource.maximum_size_estimated = 10
+                if not resource.content_type:
+                    resource.content_type = "text/plain"
+                if not resource.resource_type:
+                    resource.resource_type = "prova"
+                if not resource.maximum_size_estimated:
+                    resource.maximum_size_estimated = 10
                 old = old.add_child(resource)
             else:
                 old = res


### PR DESCRIPTION
When adding a resource to the coapserver, it removes the parameters resource type, maximum size estimated and content type and replaces them with default values.

With this patch, this only happens, if they are not set.