### PR TITLE
Update coap_protocol.py

### DIFF
--- a/coapthon/server/coap_protocol.py
+++ b/coapthon/server/coap_protocol.py
@@ -66,7 +66,10 @@ class CoAP(DatagramProtocol):
         self.l.start(defines.EXCHANGE_LIFETIME)
 
         self.multicast = multicast
-
+        
+    def setGroup(self,g):
+        self.group = g
+        
     def startProtocol(self):
         """
         Called after protocol has started listening.
@@ -76,7 +79,7 @@ class CoAP(DatagramProtocol):
             # Set the TTL>1 so multicast will cross router hops:
             self.transport.setTTL(5)
             # Join a specific multicast group:
-            self.transport.joinGroup(defines.ALL_COAP_NODES)
+            self.transport.joinGroup(self.group)
             self.transport.setLoopbackMode(True)
 
     def stopProtocol(self):


### PR DESCRIPTION
Abbiamo modificato il file coapthon/server/coap_protocol.py in quanto non rendeva possibile al server il join a gruppi differenti da quello da te definito in defines.ALL_COAP_NODES. Abbiamo risolto implementando una funzione che permettesse di scegliere il gruppo appena istanziato e cambiando di conseguenza il parametro in ingresso alla funzione di join