### PR TITLE
[coapclient.py] Added CLI switch -f to load COAP payload from file

### DIFF
--- a/coapclient.py
+++ b/coapclient.py
@@ -13,7 +13,7 @@ def usage():
     print "\t-o, --operation=\tGET|PUT|POST|DELETE|DISCOVER|OBSERVE"
     print "\t-p, --path=\t\t\tPath of the request"
     print "\t-P, --payload=\t\tPayload of the request"
-
+    print "\t-f, --payload-file=\t\tFile with payload of the request"
 
 def client_callback(response):
     print "Callback"
@@ -66,7 +66,6 @@ def main():
     path = None
     payload = None
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "ho:p:P:", ["help", "operation=", "path=", "payload="])
         opts, args = getopt.getopt(sys.argv[1:], "ho:p:P:f:", ["help", "operation=", "path=", "payload=", "payload_file="])
     except getopt.GetoptError as err:
         # print help information and exit:

--- a/coapclient.py
+++ b/coapclient.py
@@ -67,6 +67,7 @@ def main():
     payload = None
     try:
         opts, args = getopt.getopt(sys.argv[1:], "ho:p:P:", ["help", "operation=", "path=", "payload="])
+        opts, args = getopt.getopt(sys.argv[1:], "ho:p:P:f:", ["help", "operation=", "path=", "payload=", "payload_file="])
     except getopt.GetoptError as err:
         # print help information and exit:
         print str(err)  # will print something like "option -a not recognized"
@@ -79,6 +80,9 @@ def main():
             path = a
         elif o in ("-P", "--payload"):
             payload = a
+        elif o in ("-f", "--payload-file"):
+            with open(a, 'r') as f:
+                payload = f.read()
         elif o in ("-h", "--help"):
             usage()
             sys.exit()

--- a/coapthon/client/coap_protocol.py
+++ b/coapthon/client/coap_protocol.py
@@ -413,10 +413,11 @@ class CoAP(DatagramProtocol):
             self.send(rst)
 
     def post(self, client_callback, *args, **kwargs):
-        if isinstance(args[0], tuple):
+        if isinstance(args, tuple):
             path, payload = args
             req = Request()
             req.uri_path = path
+            req._payload = payload
             if "Token" in kwargs.keys():
                 req.token = kwargs.get("Token")
                 del kwargs["Token"]


### PR DESCRIPTION
# Description
I wanted to send COAP (POST method) payloads from files on my system.
It's more flexible and helps to automate few things; also makes command line cleaner.
# Usage
```
$ coapclient.py -o POST -p coap://11.22.33.44/rd?ep=SomeName -f coap_reg.txt
```
```
Message sent to 46.101.41.26:5683
----------------------------------------
Source: None
Destination: ('11.22.33.44', 5683)
Type: CON
MID: 2
Code: POST
Token: None
Uri-Path: rd
Uri-Query: ep=EmbeddedRouter
Payload:
et=FooBarRouter
lt=120
</ns/nspaddr>;rt="ns:v6addr",</nw/state>;rt="t",</nw/ipaddr>;rt="t",</nw/backhaul/macaddr>;rt="t",</nw/backhaul/ipaddr>;rt="ns:v6addr";rt="t"

----------------------------------------
```
Where ```coap_reg.txt``` file stores payload data:
```
et=FooBarRouter
lt=120
</ns/nspaddr>;rt="ns:v6addr",</nw/state>;rt="t",</nw/ipaddr>;rt="t",</nw/backhaul/macaddr>;rt="t",</nw/backhaul/ipaddr>;rt="ns:v6addr";rt="t"
```