### PR TITLE
Set daemon=True for the receiver thread

### DIFF
--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -56,6 +56,7 @@ class CoAP(object):
 
         # self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._receiver_thread = threading.Thread(target=self.receive_datagram)
+        self._receiver_thread.daemon = True
         self._receiver_thread.start()
 
     @property


### PR DESCRIPTION
This makes the application exit cleanly if an exception occurs in the main thread.
Without this it will hang indefinitely as Python waits for all threads to return.