### PR TITLE
Fixes for reverse proxy usage

### DIFF
--- a/coapthon/reverse_proxy/coap.py
+++ b/coapthon/reverse_proxy/coap.py
@@ -8,8 +8,8 @@ import xml.etree.ElementTree as ElementTree
 import os
 import re
 
-from coapclient import HelperClient
 from coapthon import defines
+from coapthon.client.helperclient import HelperClient
 from coapthon.layers.blocklayer import BlockLayer
 from coapthon.layers.cachelayer import CacheLayer
 from coapthon.layers.forwardLayer import ForwardLayer

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='CoAPthon',
     version='4.0.0',
-    packages=['coapthon', 'coapthon.layers', 'coapthon.client', 'coapthon.server', 'coapthon.messages',
+    packages=['coapthon', 'coapthon.caching', 'coapthon.layers', 'coapthon.client', 'coapthon.server', 'coapthon.messages',
               'coapthon.forward_proxy', 'coapthon.resources', 'coapthon.reverse_proxy'],
     url='https://github.com/Tanganelli/CoAPthon',
     license='MIT License',


### PR DESCRIPTION
This is necessary to use the coapreverseproxy example outside of the CoAPthon folder.