### PR TITLE
client/coap.py: remove logging init

### DIFF
--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -19,11 +19,7 @@ from coapthon.utils import create_logging
 __author__ = 'Giacomo Tanganelli'
 
 
-if not os.path.isfile("logging.conf"):
-    create_logging()
-
 logger = logging.getLogger(__name__)
-logging.config.fileConfig("logging.conf", disable_existing_loggers=False)
 
 
 class CoAP(object):


### PR DESCRIPTION
Current code creates file `logging.conf` in current dir, which is an unexpected (and unnecessary) side effect.