### PR TITLE
Fix IPv6 support with ForwardProxy (AttributeError exception)

### DIFF
--- a/coapthon/forward_proxy/coap.py
+++ b/coapthon/forward_proxy/coap.py
@@ -170,6 +170,13 @@ class CoAP(object):
 
         print "receiving datagram"
 
+        try:
+            host, port = client_address
+        except ValueError:
+            host, port, tmp1, tmp2 = client_address
+
+        client_address = (host, port)
+        
         serializer = Serializer()
         message = serializer.deserialize(data, client_address)
         if isinstance(message, int):


### PR DESCRIPTION
IPv6 transactions through a proxy resulted in an AttributeError exception (File "/usr/local/lib/python2.7/dist-packages/coapthon/messages/message.py", line 204, in destination)