### PR TITLE
Update serialization of options with two-byte extended numbers

### DIFF
--- a/coapthon/defines.py
+++ b/coapthon/defines.py
@@ -166,10 +166,10 @@ class OptionRegistry(object):
         opt_bytes = array.array('B', '\0\0')
         if option_num < 256:
             s = struct.Struct("!B")
-            opt_bytes = s.pack_into(opt_bytes, 0, option_num)
+            s.pack_into(opt_bytes, 0, option_num)
         else:
-            s = struct.Struct("!H")
-            opt_bytes = s.pack_into(opt_bytes, 0, option_num)
+            s = struct.Struct("H")
+            s.pack_into(opt_bytes, 0, option_num)
         critical = (opt_bytes[0] & 0x01) > 0
         unsafe = (opt_bytes[0] & 0x02) > 0
         nocache = ((opt_bytes[0] & 0x1e) == 0x1c)

--- a/coapthon/serializer.py
+++ b/coapthon/serializer.py
@@ -72,9 +72,9 @@ class Serializer(object):
                     try:
                         option_item = defines.OptionRegistry.LIST[current_option]
                     except KeyError:
-                        (opt_critical, _, _) = defines.get_option_flags(current_option)
+                        (opt_critical, _, _) = defines.OptionRegistry.get_option_flags(current_option)
                         if opt_critical:
-                            raise AttributeError
+                            raise AttributeError("Critical option %s unknown" % current_option)
                         else:
                             # If the non-critical option is unknown
                             # (vendor-specific, proprietary) - just skip it
@@ -110,7 +110,7 @@ class Serializer(object):
 
                     if length_packet <= pos:
                         # log.err("Payload Marker with no payload")
-                        raise AttributeError
+                        raise AttributeError("Packet length %s, pos %s" % (length_packet, pos))
                     message.payload = ""
                     payload = values[pos:]
                     for b in payload:
@@ -171,15 +171,15 @@ class Serializer(object):
                 fmt += "B"
                 values.append(optiondelta - 13)
             elif optiondeltanibble == 14:
-                fmt += "B"
-                values.append(optiondelta - 296)
+                fmt += "H"
+                values.append(optiondelta - 269)
 
             # write extended option length field (0 - 2 bytes)
             if optionlengthnibble == 13:
                 fmt += "B"
                 values.append(optionlength - 13)
             elif optionlengthnibble == 14:
-                fmt += "B"
+                fmt += "H"
                 values.append(optionlength - 269)
 
             # write option value


### PR DESCRIPTION
Update serialization of options with two-byte extended numbers:
- fix extension calculation
- fix options flags calculation (critical, safe, cached)
- add a test to check handling of unrecognized options (critical vs elective) with one- and two-byte extended numbers