### PR TITLE
Fix KeyError due to identation problem

### DIFF
--- a/coapthon/layers/blocklayer.py
+++ b/coapthon/layers/blocklayer.py
@@ -180,7 +180,7 @@ class BlockLayer(object):
                         logger.error("Content-type Error")
                         return self.error(transaction, defines.Codes.UNSUPPORTED_CONTENT_FORMAT.number)
                     transaction.response.payload = self._block2_sent[key_token].payload + transaction.response.payload
-                del self._block2_sent[key_token]
+                    del self._block2_sent[key_token]
         else:
             transaction.block_transfer = False
         return transaction


### PR DESCRIPTION
Using the forward_proxy with an intermittent link to the server the following error was being generated:

```
  File "/usr/local/lib/python2.7/dist-packages/coapthon/layers/blocklayer.py", line 183, in receive_response
    del self._block2_sent[key_token]
KeyError: -8448607242250672825
```