### PR TITLE
Fwd layer crash when server unavailable

### DIFF
--- a/coapthon/layers/forwardLayer.py
+++ b/coapthon/layers/forwardLayer.py
@@ -101,9 +101,13 @@ class ForwardLayer(object):
         request.code = transaction.request.code
         response = client.send_request(request)
         client.stop()
-        transaction.response.payload = response.payload
-        transaction.response.code = response.code
-        transaction.response.options = response.options
+        if response is not None:
+            transaction.response.payload = response.payload
+            transaction.response.code = response.code
+            transaction.response.options = response.options
+        else:
+            transaction.response.code = defines.Codes.SERVICE_UNAVAILABLE.number
+
         return transaction
 
     def _handle_request(self, transaction, new_resource):


### PR DESCRIPTION
The Forward Layer crashes after giving up on retransmission of request if the server is unavailable. Fixed by using the 5.03 SERVICE_UNAVAILABLE, which seemed the most suitable code.

> 2017-04-12 18:51:10,333 - Thread-26  - coapthon.client.coap - DEBUG - Exiting receiver Thread due to request
> Exception in thread Thread-7:
> Traceback (most recent call last):
>   File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
>     self.run()
>   File "/usr/lib/python2.7/threading.py", line 754, in run
>     self.__target(*self.__args, **self.__kwargs)
>   File "/usr/local/lib/python2.7/dist-packages/coapthon/forward_proxy/coap.py", line 286, in receive_datagram
>     transaction = self._forwardLayer.receive_request(transaction)
>   File "/usr/local/lib/python2.7/dist-packages/coapthon/layers/forwardLayer.py", line 34, in receive_request
>     return self._forward_request(transaction, (host, port), path)
>   File "/usr/local/lib/python2.7/dist-packages/coapthon/layers/forwardLayer.py", line 104, in _forward_request
>     transaction.response.payload = response.payload
> AttributeError: 'NoneType' object has no attribute 'payload'
