### PR TITLE
Enable multi-threaded forwarding

### DIFF
--- a/coapthon/forward_proxy/coap.py
+++ b/coapthon/forward_proxy/coap.py
@@ -143,7 +143,11 @@ class CoAP(object):
             except socket.timeout:
                 continue
             try:
-                self.receive_datagram((data, client_address))
+                #Start a new thread not to block other requests
+                args = ((data, client_address), )
+                t = threading.Thread(target=self.receive_datagram, args=args)
+                t.daemon = True
+                t.start()
             except RuntimeError:
                 print "Exception with Executor"
         print "closing socket"


### PR DESCRIPTION
The `forward_proxy `is only accepting one request at a time, which is particularly unsuitable if the server is not responding or we have intermittent links. For example, if for some reason the first ACK sent be the proxy is lost, no other ACKs are sent (until the response), and the client might give up if the server is taking some time to respond.