### PR TITLE
Lost ACKs and message deduplication

### DIFF
--- a/coapthon/layers/messagelayer.py
+++ b/coapthon/layers/messagelayer.py
@@ -177,6 +177,12 @@ class MessageLayer(object):
                 transaction.request.rejected = True
             elif not transaction.response.acknowledged:
                 transaction.response.rejected = True
+        elif message.type == defines.Types["CON"]:
+            #implicit ACK (might have been lost)
+            logger.debug("Implicit ACK on received CON for waiting transaction")
+            transaction.request.acknowledged = True
+        else:
+            logger.warning("Unhandled message type...")
 
         if transaction.retransmit_stop is not None:
             transaction.retransmit_stop.set()


### PR DESCRIPTION
When using the threaded-version forward_proxy it might occur that the first ACK (sent by the proxy is lost) and the client will retransmit the request. This leads to a duplicate message detection by the proxy which in turn sends an empty message with the new CON identifier. Without this fix the client will receive the empty message that corresponds to an existing transaction and stop the retransmission without acknowledging this transaction.

From the RFC there are several approaches to handle these duplicates (https://tools.ietf.org/html/rfc7252#section-4.5), I opted to implicitly acknowledge the transaction when receiving the CON message to avoid sending another ACK.

One way to reproduce this is for the ACK to be lost and completely drop all the packets sent to the server. I used `tc`.

First create a qdisc on the proxy so it receives packets but it's own are lost (1 for proxy-client and 1 proxy-server interfaces):
```
tc qdisc del dev ethX root
tc qdisc add dev ethX root netem loss 100%
```
Let the first ACK be lost, and immediately after the retransmission from the client, clear the losses from the proxy-client interface:
```
tc qdisc change dev eth1 root netem loss 0%
```
This should result in an empty `CON` message being received by the client and it giving up on the request.