### PR TITLE
avoid exception in receive_empty for None response

### DIFF
--- a/coapthon/layers/messagelayer.py
+++ b/coapthon/layers/messagelayer.py
@@ -170,7 +170,7 @@ class MessageLayer(object):
         if message.type == defines.Types["ACK"]:
             if not transaction.request.acknowledged:
                 transaction.request.acknowledged = True
-            elif not transaction.response.acknowledged:
+            elif (transaction.response is not None) and (not transaction.response.acknowledged):
                 transaction.response.acknowledged = True
         elif message.type == defines.Types["RST"]:
             if not transaction.request.acknowledged:


### PR DESCRIPTION
In non-determined situations -- it seems that it happens when receiving two almost simultaneous ACKs (concurrency maybe?) -- the `receive_empty` occurs without acknowledging the request, falling into the `if` branch of the `transaction.response`, which does not exist (it happens on the client making the request through a proxy).

```
2017-05-26 15:49:53,533 - Thread-1   - coapthon.layers.messagelayer - DEBUG - receive_empty - From ('b:1::1', 5683), To None, ACK-54410, EMPTY-None, [] No payload
2017-05-26 15:49:53,562 - MainThread-Retry-54410 - coapthon.client.coap - DEBUG - retransmit loop ... exit
2017-05-26 15:49:54,257 - Thread-1   - coapthon.layers.messagelayer - DEBUG - receive_empty - From ('b:1::1', 5683), To None, ACK-54410, EMPTY-None, [] No payload
Exception in thread Thread-1:
Traceback (most recent call last):
...
    self._messageLayer.receive_empty(message)
  File "/usr/local/lib/python2.7/dist-packages/coapthon/layers/messagelayer.py", line 173, in receive_empty
    elif not transaction.response.acknowledged:
AttributeError: 'NoneType' object has no attribute 'acknowledged'
```