### PR TITLE
Replace calls to print()

### DIFF
--- a/coapthon/caching/cache.py
+++ b/coapthon/caching/cache.py
@@ -32,7 +32,7 @@ class Cache(object):
         :param response:
         :return:
         """
-        print "adding response to the cache"
+        logger.debug("adding response to the cache")
 
         """
         checking for valid code

--- a/coapthon/caching/coaplrucache.py
+++ b/coapthon/caching/coaplrucache.py
@@ -1,7 +1,11 @@
+import logging
+
 from cachetools import LRUCache
 from coapthon.caching.coapcache import CoapCache
 
 __author__ = 'Emilio Vallati'
+
+logger = logging.getLogger(__name__)
 
 
 class CoapLRUCache(CoapCache):
@@ -19,9 +23,8 @@ class CoapLRUCache(CoapCache):
         :param element:
         :return:
         """
-        print "updating cache"
-        print "key: ", key.hashkey
-        print "element: ", element
+        logger.debug("updating cache, key: %s, element: %s", \
+                key.hashkey, element)
         self.cache.update([(key.hashkey, element)])
 
     def get(self, key):
@@ -33,7 +36,7 @@ class CoapLRUCache(CoapCache):
         try:
             response = self.cache[key.hashkey]
         except KeyError:
-            print "problem here"
+            logger.debug("problem here", exc_info=1)
             response = None
         return response
 
@@ -66,10 +69,15 @@ class CoapLRUCache(CoapCache):
 
         :return:
         """
-        print "size = ", self.cache.currsize
-        list = self.cache.items()
-        for key, element in list:
-            print "element.max age ", element.max_age
-            print "element.uri", element.uri
-            print "element.freshness ", element.freshness
-
+        return ("size = %s\n%s" % (
+            self.cache.currsize,
+            '\n'.join([
+                (   "element.max age %s\n"\
+                    "element.uri %s\n"\
+                    "element.freshness %s"  ) % (
+                        element.max_age,
+                        element.uri,
+                        element.freshness )
+                for key, element
+                in list(self.cache.items())
+            ])))

--- a/coapthon/forward_proxy/coap.py
+++ b/coapthon/forward_proxy/coap.py
@@ -149,8 +149,8 @@ class CoAP(object):
                 t.daemon = True
                 t.start()
             except RuntimeError:
-                print "Exception with Executor"
-        print "closing socket"
+                logging.exception("Exception with Executor")
+        logging.debug("closing socket")
         self._socket.close()
 
     def close(self):
@@ -172,7 +172,7 @@ class CoAP(object):
         """
         data, client_address = args
 
-        print "receiving datagram"
+        logging.debug("receiving datagram")
 
         try:
             host, port = client_address
@@ -229,9 +229,9 @@ class CoAP(object):
                 transaction = self._cacheLayer.receive_request(transaction)
 
                 if transaction.cacheHit is False:
-                    print transaction.request
+                    logging.debug(transaction.request)
                     transaction = self._forwardLayer.receive_request(transaction)
-                    print transaction.response
+                    logging.debug(transaction.response)
 
                 transaction = self._observeLayer.send_response(transaction)
 

--- a/coapthon/layers/cachelayer.py
+++ b/coapthon/layers/cachelayer.py
@@ -1,9 +1,12 @@
+import logging
 
 from coapthon.defines import Codes
 
 from coapthon.caching.cache import *
 
 __author__ = 'Emilio Vallati'
+
+logger = logging.getLogger(__name__)
 
 
 class CacheLayer(object):
@@ -34,7 +37,7 @@ class CacheLayer(object):
             age = transaction.cached_element.creation_time + transaction.cached_element.max_age - time.time()
             if transaction.cached_element.freshness is True:
                 if age <= 0:
-                    print "resource not fresh"
+                    logger.debug("resource not fresh")
                     """
                     if the resource is not fresh, its Etag must be added to the request so that the server might validate it instead of sending a new one
                     """
@@ -43,7 +46,7 @@ class CacheLayer(object):
                     ensuring that the request goes to the server
                     """
                     transaction.cacheHit = False
-                    print "requesting etag ", transaction.response.etag
+                    logger.debug("requesting etag %s", transaction.response.etag)
                     transaction.request.etag = transaction.response.etag
                 else:
                     transaction.response.max_age = age
@@ -62,7 +65,7 @@ class CacheLayer(object):
             """
             handling response based on the code
             """
-            print "handling response"
+            logger.debug("handling response")
             self._handle_response(transaction)
         return transaction
 
@@ -82,7 +85,7 @@ class CacheLayer(object):
         if the request etag is different from the response, send the cached response
         """
         if code == Codes.VALID.number:
-            print "received VALID"
+            logger.debug("received VALID")
             self.cache.validate(transaction.request, transaction.response)
             if transaction.request.etag != transaction.response.etag:
                 element = self.cache.search_response(transaction.request)

--- a/coapthon/reverse_proxy/coap.py
+++ b/coapthon/reverse_proxy/coap.py
@@ -243,7 +243,7 @@ class CoAP(object):
 
                 self.receive_datagram((data, client_address))
             except RuntimeError:
-                print "Exception with Executor"
+                logger.exception("Exception with Executor")
         self._socket.close()
 
     def close(self):
@@ -313,9 +313,9 @@ class CoAP(object):
                 transaction = self._cacheLayer.receive_request(transaction)
 
                 if transaction.cacheHit is False:
-                    print transaction.request
+                    logger.debug(transaction.request)
                     transaction = self._forwardLayer.receive_request_reverse(transaction)
-                    print transaction.response
+                    logger.debug(transaction.response)
 
                 transaction = self._observeLayer.send_response(transaction)
 

--- a/coapthon/serializer.py
+++ b/coapthon/serializer.py
@@ -1,3 +1,4 @@
+import logging
 import struct
 import ctypes
 from coapthon.messages.request import Request
@@ -7,6 +8,8 @@ from coapthon import defines
 from coapthon.messages.message import Message
 
 __author__ = 'Giacomo Tanganelli'
+
+logger = logging.getLogger(__name__)
 
 
 class Serializer(object):
@@ -224,10 +227,10 @@ class Serializer(object):
             s = struct.Struct(fmt)
             datagram = ctypes.create_string_buffer(s.size)
             s.pack_into(datagram, 0, *values)
-        except struct.error as e:
-            print values
-            print e.args
-            print e.message
+        except struct.error:
+            # The .exception method will report on the exception encountered
+            # and provide a traceback.
+            logging.exception('Failed to pack structure')
 
         return datagram
 

--- a/coapthon/server/coap.py
+++ b/coapthon/server/coap.py
@@ -182,7 +182,7 @@ class CoAP(object):
                             self._observeLayer.receive_empty(message, transaction)
 
             except RuntimeError:
-                print "Exception with Executor"
+                logger.exception("Exception with Executor")
         self._socket.close()
 
     def close(self):


### PR DESCRIPTION
These are mostly debug messages that really should go to a log for two
reasons:

1. the user of the library may not care to see such messages, in fact,
   emitting the messages to stdout may be downright harmful (think
   streaming a binary file to `stdout`?)
2. the process may be a daemon, in which case, filehandles 0, 1 and 2
   will be closed, writing to these will achieve nothing.

This addresses issue #89.