### PR TITLE
Fix Empty exception for timeout in send_request

### DIFF
--- a/coapthon/client/helperclient.py
+++ b/coapthon/client/helperclient.py
@@ -1,5 +1,6 @@
 import random
 from multiprocessing import Queue
+from Queue import Empty
 import threading
 from coapthon.messages.message import Message
 from coapthon import defines
@@ -203,7 +204,11 @@ class HelperClient(object):
             thread.start()
         else:
             self.protocol.send_message(request)
-            response = self.queue.get(block=True, timeout=timeout)
+            try:
+                response = self.queue.get(block=True, timeout=timeout)
+            except Empty:
+                #if timeout is set
+                response = None
             return response
 
     def send_empty(self, empty):  # pragma: no cover


### PR DESCRIPTION
If the timeout parameter is set when making a request, for example when working with non-confirmable requests, the Empty exception may be raised and needs to be handled.

> 
> Traceback (most recent call last):
>   File "nonclient.py", line 202, in <module>
>     main()
>   File "nonclient.py", line 139, in main
>     response = client.send_request(req, None, 5)
>   File "/root/CoAPthon/coapthon/client/helperclient.py", line 206, in send_request
>     response = self.queue.get(block=True, timeout=timeout)
>   File "/usr/lib/python2.7/multiprocessing/queues.py", line 132, in get
>     raise Empty
> Queue.Empty