### PR TITLE
Fixing #107 lock-up when a confirmed transaction times out

### DIFF
--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -233,7 +233,7 @@ class CoAP(object):
                 message.timeouted = True
 
                 # Inform the user, that nothing was received
-                self._callback(None)
+                self._callback(message)
 
             try:
                 self.to_be_stopped.remove(transaction.retransmit_stop)

--- a/coapthon/client/helperclient.py
+++ b/coapthon/client/helperclient.py
@@ -43,14 +43,15 @@ class HelperClient(object):
 
         :param message: the received message
         """
-        if not message:
-            return
         if message.code == defines.Codes.CONTINUE.number:
             return
         with self.requests_lock:
             if message.token not in self.requests:
                 return
             context = self.requests[message.token]
+            if message.timeouted:
+                # Message is actually the original timed out request (not the response), discard content
+                message = None
             if hasattr(context, 'callback'):
                 if not hasattr(context.request, 'observe'):
                     # OBSERVE stays until cancelled, for all others we're done


### PR DESCRIPTION
Pass back original request message during timeout so HelperClient can distinguish which request timed out and respond accordingly.