### PR TITLE
Add an observe refresh method to the helper client

### DIFF
--- a/coapthon/client/helperclient.py
+++ b/coapthon/client/helperclient.py
@@ -162,6 +162,20 @@ class HelperClient(object):
 
         return self.send_request(request, callback, timeout)
 
+    def refresh_observation(self, token):
+        """
+        Re-register interest with the server in the previously observed resource.
+
+        :param token: the token returned from the original observe request
+        """
+        with self.requests_lock:
+            if token not in self.requests:
+                return
+            if not hasattr(self.requests[token].request, 'observe'):
+                return
+            context = self.requests[token]
+        self.protocol.send_message(context.request)
+
     def delete(self, path, proxy_uri=None, callback=None, timeout=None, **kwargs):  # pragma: no cover
         """
         Perform a DELETE on a certain path.


### PR DESCRIPTION
RFC 7641 in section 3.3.1 'Freshness' says that a client may issue a new
GET request with the original token at any time.

So, we shouldn't do it for them, but we should make it easy for them to
follow the RFC - i.e. if they were to send a request via the existing mechanism,
we would change the token, even if it were specified.

This part of the RFC means that if the server restarts or loses the
confirmation, and the client believes it is still observing, it would
otherwise not receive new updates.  If the client does send a refresh,
it does not cause additional connections to the server (the existing one
MUST be replaced) and knows that the server is still sending back
notifications.