### PR TITLE
Fix message layer threading issues

### DIFF
--- a/coap.py
+++ b/coap.py
@@ -361,8 +361,6 @@ class CoAP(object):
                 self.to_be_stopped.remove(transaction.retransmit_stop)
             except ValueError:
                 pass
-            transaction.retransmit_stop = None
-            transaction.retransmit_thread = None
 
     def _start_separate_timer(self, transaction):
         """

--- a/coapthon/client/coap.py
+++ b/coapthon/client/coap.py
@@ -143,11 +143,11 @@ class CoAP(object):
         Only one retransmit thread at a time, wait for other to finish
         
         """
-        if hasattr(transaction, 'retransmit_thread'):
-            while transaction.retransmit_thread is not None:
-                logger.debug("Waiting for retransmit thread to finish ...")
-                time.sleep(0.01)
-                continue
+        if transaction.retransmit_thread is not None:
+            try:
+                transaction.retransmit_thread.join()
+            except RuntimeError:  # Catches the thread not having started
+                pass
 
     def _send_block_request(self, transaction):
         """
@@ -239,8 +239,6 @@ class CoAP(object):
                 self.to_be_stopped.remove(transaction.retransmit_stop)
             except ValueError:
                 pass
-            transaction.retransmit_stop = None
-            transaction.retransmit_thread = None
 
             logger.debug("retransmit loop ... exit")
 

--- a/coapthon/forward_proxy/coap.py
+++ b/coapthon/forward_proxy/coap.py
@@ -326,8 +326,6 @@ class CoAP(object):
                 self.to_be_stopped.remove(transaction.retransmit_stop)
             except ValueError:
                 pass
-            transaction.retransmit_stop = None
-            transaction.retransmit_thread = None
 
     def _start_separate_timer(self, transaction):
         """

--- a/coapthon/resource_directory/coap.py
+++ b/coapthon/resource_directory/coap.py
@@ -368,8 +368,6 @@ class CoAP(object):
                 self.to_be_stopped.remove(transaction.retransmit_stop)
             except ValueError:
                 pass
-            transaction.retransmit_stop = None
-            transaction.retransmit_thread = None
 
     def _start_separate_timer(self, transaction):
         """

--- a/coapthon/reverse_proxy/coap.py
+++ b/coapthon/reverse_proxy/coap.py
@@ -438,8 +438,6 @@ class CoAP(object):
                 self.to_be_stopped.remove(transaction.retransmit_stop)
             except ValueError:
                 pass
-            transaction.retransmit_stop = None
-            transaction.retransmit_thread = None
 
     def _start_separate_timer(self, transaction):
         """

--- a/coapthon/server/coap.py
+++ b/coapthon/server/coap.py
@@ -361,8 +361,6 @@ class CoAP(object):
                 self.to_be_stopped.remove(transaction.retransmit_stop)
             except ValueError:
                 pass
-            transaction.retransmit_stop = None
-            transaction.retransmit_thread = None
 
     def _start_separate_timer(self, transaction):
         """


### PR DESCRIPTION
Occasionally, we will see a 'NoneType object has no member 'set'`
directly after an if-statement checking to see that the offending object
is _not_ None.  This smells of threading problems, so I've made setting
the object to None (presumably encouraging the thread to be garbage
collected) less agressive, and certainly not from within the function
which is being run by the thread - that seems like a recipe for
problems such as this.

The trade-off is that the (old) memory is cleared when a new retransmit
operation is started, not after the initial retransmit has completed,
but the value gained is correctness.