### PR TITLE
Correct Python ImportError - remove DynamicResource from coapserver.py

### DIFF
--- a/coapserver.py
+++ b/coapserver.py
@@ -5,7 +5,7 @@ import sys
 from coapthon.server.coap import CoAP
 from exampleresources import BasicResource, Long, Separate, Storage, Big, voidResource, XMLResource, ETAGResource, \
     Child, \
-    MultipleEncodingResource, AdvancedResource, AdvancedResourceSeparate, DynamicResource
+    MultipleEncodingResource, AdvancedResource, AdvancedResourceSeparate
 
 __author__ = 'Giacomo Tanganelli'
 
@@ -25,7 +25,6 @@ class CoAPServer(CoAP):
         self.add_resource('child/', Child())
         self.add_resource('advanced/', AdvancedResource())
         self.add_resource('advancedSeparate/', AdvancedResourceSeparate())
-        self.add_resource('dynamic/', DynamicResource())
 
         print "CoAP Server start on " + host + ":" + str(port)
         print self.root.dump()


### PR DESCRIPTION
Remove DynamicResource from `coapserver.py` since it is not defined in `exampleresources.py`.